### PR TITLE
Fix: Update product validation to use English keys in server.js

### DIFF
--- a/products.json
+++ b/products.json
@@ -1,23 +1,23 @@
 [
   {
     "id": "taco-pastor",
-    "nombre": "Orden de Tacos al Pastor",
-    "descripcion": "Tres deliciosos tacos de carne al pastor marinada con nuestra receta secreta.",
-    "precio": 100,
+    "name": "Orden de Tacos al Pastor",
+    "description": "Tres deliciosos tacos de carne al pastor marinada con nuestra receta secreta.",
+    "price": 100,
     "stock": 50
   },
   {
     "id": "taco-asada",
-    "nombre": "Orden de Tacos de Asada",
-    "descripcion": "Tres tacos de jugosa carne asada a la parrilla.",
-    "precio": 100,
+    "name": "Orden de Tacos de Asada",
+    "description": "Tres tacos de jugosa carne asada a la parrilla.",
+    "price": 100,
     "stock": 45
   },
   {
     "id": "refresco",
-    "nombre": "Refresco",
-    "descripcion": "Una bebida bien fría para acompañar tus tacos.",
-    "precio": 30,
+    "name": "Refresco",
+    "description": "Una bebida bien fría para acompañar tus tacos.",
+    "price": 30,
     "stock": 100
   }
 ]

--- a/server.js
+++ b/server.js
@@ -36,7 +36,7 @@ const PRODUCTS_PATH = './products.json';
 // --- Middleware ---
 // Habilitar CORS para permitir peticiones desde tu frontend de React
 app.use(cors({
-  origin: 'http://localhost:5174', // ACTUALIZADO: Cambiado a 5174 según requisitos
+  origin: 'http://localhost:5173', // ACTUALIZADO: Cambiado a 5173 según requisitos
   methods: ['GET', 'POST', 'PUT'], // Añadido PUT por si acaso, aunque no se pide explícitamente
 }));
 
@@ -214,10 +214,11 @@ app.post('/api/products', async (req, res) => {
   try {
     const newProduct = req.body;
 
-    // Validación básica del producto recibido
-    if (!newProduct || typeof newProduct !== 'object' || !newProduct.nombre || !newProduct.precio) {
+    // --- LA CORRECCIÓN ESTÁ AQUÍ ---
+    // Validación básica del producto recibido, ahora esperando claves en inglés
+    if (!newProduct || typeof newProduct !== 'object' || !newProduct.name || newProduct.price === undefined) {
         console.warn('Petición POST a /api/products rechazada por cuerpo inválido:', newProduct);
-        return res.status(400).json({ message: 'Cuerpo de la solicitud de producto inválido. Se requiere al menos nombre y precio.' });
+        return res.status(400).json({ message: 'Cuerpo de la solicitud de producto inválido. Se requiere al menos "name" y "price".' });
     }
 
     let products = [];


### PR DESCRIPTION
Adjusted the validation logic in the POST `/api/products` route to expect 'name' and 'price' (English) instead of 'nombre' and 'precio' (Spanish). This aligns the backend validation with the frontend data structure and the standardized keys in `products.json`.